### PR TITLE
Potential fix for code scanning alert no. 29: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.1",
-    "wisp-server-node": "^1.1.3"
+    "wisp-server-node": "^1.1.3",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 import { Curl } from 'node-libcurl';
 import fastifyStatic from "@fastify/static";
 import fastifyCookie from "@fastify/cookie";
+import fastifyRateLimit from "@fastify/rate-limit";
 import wisp from "wisp-server-node";
 import { join } from "node:path";
 import { access } from "node:fs/promises";
@@ -31,6 +32,10 @@ const app = Fastify({
 });
 
 await app.register(fastifyCookie);
+await app.register(fastifyRateLimit, {
+  max: 100, // limit each IP to 100 requests per windowMs
+  timeWindow: "15 minutes", // 15 minute window
+});
 [
   { root: join(import.meta.dirname, "public"), prefix: "/", decorateReply: true },
   { root: libcurlPath, prefix: "/libcurl/" },,


### PR DESCRIPTION
Potential fix for [https://github.com/jkjkjiin/Space-proxy/security/code-scanning/29](https://github.com/jkjkjiin/Space-proxy/security/code-scanning/29)

To mitigate denial-of-service attacks, the best practice is to introduce rate limiting for HTTP request handlers that perform file system access or other expensive operations. For Fastify, well-known solutions include fastify-rate-limit. The fix is to import and register fastify-rate-limit, then apply a suitable policy—for example, a reasonable number of requests per IP per time window. This should be applied globally (all routes) or at minimum to the `/uv/*` route and any others with file system or similarly expensive access.  

The fix involves:
- Installing and importing `@fastify/rate-limit`.
- Registering the rate limit middleware before defining routes.
- Optionally customizing rate limits to match your threat model (e.g., max 100 requests per 15 minutes per IP).
- Only changes inside server.js and import section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
